### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Piotr Kowalski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ In settings:
 
 ## License
 
-[The MIT License](https://piecioshka.mit-license.org) @ 2014
+[The MIT License](http://piecioshka.mit-license.org) @ 2026

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "files": [
         "demo",
         "src",
-        "README.md"
+        "README.md",
+        "LICENSE"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adds an MIT `LICENSE` file (Copyright (c) 2026 Piotr Kowalski), declares the license in `package.json` (npm) and adds a License section to the README.